### PR TITLE
Fixes to make Configuration round trip correctly

### DIFF
--- a/gopom.go
+++ b/gopom.go
@@ -265,8 +265,8 @@ type Dependency struct {
 }
 
 type Exclusion struct {
-	ArtifactID string `xml:"artifactId,omitempty"`
 	GroupID    string `xml:"groupId,omitempty"`
+	ArtifactID string `xml:"artifactId,omitempty"`
 }
 
 type Repository struct {
@@ -333,6 +333,20 @@ type PluginManagement struct {
 	Plugins *[]Plugin `xml:"plugins>plugin,omitempty"`
 }
 
+// Configuration is a raw XML configuration that we currently do not muck with.
+// It's supposed to be a DOM object, but upstream uses map[string]string for
+// properties, and it does not work. For now, just keep it as a string so we
+// can marshal it out untouched.
+// TODO: This should be a DOM object.
+// TODO: For some reason this loses the following XML attributes (probably all
+// attributes):
+// <configuration combine.children="merge">
+// When marshalled, it is just:
+// <configuration>
+type Configuration struct {
+	RawConfiguration string `xml:",innerxml"`
+}
+
 type Plugin struct {
 	GroupID       string             `xml:"groupId,omitempty"`
 	ArtifactID    string             `xml:"artifactId,omitempty"`
@@ -341,7 +355,7 @@ type Plugin struct {
 	Executions    *[]PluginExecution `xml:"executions>execution,omitempty"`
 	Dependencies  *[]Dependency      `xml:"dependencies>dependency,omitempty"`
 	Inherited     string             `xml:"inherited,omitempty"`
-	Configuration *Properties        `xml:"configuration,omitempty"`
+	Configuration *Configuration     `xml:"configuration,omitempty"`
 }
 
 type PluginExecution struct {

--- a/gopom.go
+++ b/gopom.go
@@ -223,13 +223,13 @@ type CIManagement struct {
 }
 
 type Notifier struct {
-	Type          string      `xml:"type,omitempty"`
-	SendOnError   bool        `xml:"sendOnError,omitempty"`
-	SendOnFailure bool        `xml:"sendOnFailure,omitempty"`
-	SendOnSuccess bool        `xml:"sendOnSuccess,omitempty"`
-	SendOnWarning bool        `xml:"sendOnWarning,omitempty"`
-	Address       string      `xml:"address,omitempty"`
-	Configuration *Properties `xml:"configuration,omitempty"`
+	Type          string         `xml:"type,omitempty"`
+	SendOnError   bool           `xml:"sendOnError,omitempty"`
+	SendOnFailure bool           `xml:"sendOnFailure,omitempty"`
+	SendOnSuccess bool           `xml:"sendOnSuccess,omitempty"`
+	SendOnWarning bool           `xml:"sendOnWarning,omitempty"`
+	Address       string         `xml:"address,omitempty"`
+	Configuration *Configuration `xml:"configuration,omitempty"`
 }
 
 type DistributionManagement struct {
@@ -365,10 +365,11 @@ type Plugin struct {
 }
 
 type PluginExecution struct {
-	ID        string    `xml:"id,omitempty"`
-	Phase     string    `xml:"phase,omitempty"`
-	Goals     *[]string `xml:"goals>goal,omitempty"`
-	Inherited string    `xml:"inherited,omitempty"`
+	ID            string         `xml:"id,omitempty"`
+	Phase         string         `xml:"phase,omitempty"`
+	Goals         *[]string      `xml:"goals>goal,omitempty"`
+	Inherited     string         `xml:"inherited,omitempty"`
+	Configuration *Configuration `xml:"configuration,omitempty"`
 }
 
 type Reporting struct {


### PR DESCRIPTION
* Configuration is supposed to be a DOM object, and using a map[string]string does not work correctly. Since we do not muck about with the Configuration (it's opaque and depends on the plugin), treat it as innerxml.
* Order properties to reduce diffs when round tripping.