### PR TITLE
feat: add initial support for direct dependencies search

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,9 @@
+package gopom
+
+import (
+	"github.com/pkg/errors"
+)
+
+var (
+	ErrDepNotFound = errors.New("dependency not found")
+)

--- a/errors.go
+++ b/errors.go
@@ -5,5 +5,6 @@ import (
 )
 
 var (
-	ErrDepNotFound = errors.New("dependency not found")
+	ErrDepNotFound   = errors.New("dependency not found")
+	ErrDepCacheEmpty = errors.New("dependency cache empty")
 )

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,10 @@ module github.com/chainguard-dev/gopom
 
 go 1.21
 
-require github.com/stretchr/testify v1.6.1
+require (
+	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.6.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/gopom_test.go
+++ b/gopom_test.go
@@ -44,6 +44,7 @@ func TestParsing(t *testing.T) {
 	testContributorProperties(t, p)
 	testProfileProperties(t, p)
 	testMarshal(t, p)
+	testSearch(t, p)
 }
 
 func testMarshal(t *testing.T, p *Project) {
@@ -379,7 +380,7 @@ func testDependencyManagement(t *testing.T, p *Project) {
 }
 
 func testDependencies(t *testing.T, p *Project) {
-	assert.Equal(t, 1, len(*p.Dependencies))
+	assert.Equal(t, 3, len(*p.Dependencies))
 	d := (*p.Dependencies)[0]
 	assert.Equal(t, "groupId", d.GroupID)
 	assert.Equal(t, "artifactId", d.ArtifactID)
@@ -766,4 +767,16 @@ func testProfileProperties(t *testing.T, p *Project) {
 	assert.Equal(t, "value", p.Properties.Entries["key"])
 	assert.Equal(t, "value2", p.Properties.Entries["key2"])
 	assert.Equal(t, "value3", p.Properties.Entries["key3"])
+}
+
+func testSearch(t *testing.T, p *Project) {
+	dep, err := p.Search("org.example.foo", "foo")
+	assert.Nil(t, err)
+	assert.NotNil(t, dep)
+	assert.Equal(t, "org.example.foo", dep.GroupID)
+	assert.Equal(t, "foo", dep.ArtifactID)
+	assert.Equal(t, "1.0.0", dep.Version)
+	assert.Equal(t, "type", dep.Type)
+	assert.Equal(t, "classifier", dep.Classifier)
+	assert.Equal(t, 1, len(*dep.Exclusions))
 }

--- a/testdata/example.xml
+++ b/testdata/example.xml
@@ -223,6 +223,38 @@
         </exclusions>
         <optional>optional</optional>
       </dependency>
+    <dependency>
+      <groupId>org.example.foo</groupId>
+      <artifactId>foo</artifactId>
+      <version>1.0.0</version>
+      <type>type</type>
+      <classifier>classifier</classifier>
+      <scope>scope</scope>
+      <systemPath>systemPath</systemPath>
+      <exclusions>
+        <exclusion>
+          <artifactId>artifactId</artifactId>
+          <groupId>groupId</groupId>
+        </exclusion>
+      </exclusions>
+      <optional>optional</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.example.bar</groupId>
+      <artifactId>foo</artifactId>
+      <version>1.0.1</version>
+      <type>type</type>
+      <classifier>classifier</classifier>
+      <scope>scope</scope>
+      <systemPath>systemPath</systemPath>
+      <exclusions>
+        <exclusion>
+          <artifactId>artifactId</artifactId>
+          <groupId>groupId</groupId>
+        </exclusion>
+      </exclusions>
+      <optional>optional</optional>
+    </dependency>
   </dependencies>
 
   <repositories>


### PR DESCRIPTION
It introduces support for direct dependencies search with O(1) complexity via a simple hash map.
It supports the root level dependencies list.

Tests have been added and fixtures updated for the new feature.